### PR TITLE
Add boolean tests and fix boolean logic

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -43,9 +43,9 @@ module.exports = {
   toBoolean: function (value) {
     if(lodash.isNumber(value) || (""+value).match(/^[0-9]+$/)) {
       return (value > 0);
-    } else if (value === true || /^(true|on|yes|1)$/.test(value)) {
+    } else if (value === true || /^(true|on|yes)$/.test(value)) {
       return true;
-    }  else if (value === false || /^(false|off|no|0)$/.test(value)) {
+    }  else if (value === false || /^(false|off|no)$/.test(value)) {
       return false;
     } else {
       return value;

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -41,9 +41,11 @@ module.exports = {
     }
   },
   toBoolean: function (value) {
-    if (value === 1 || value === true || /^(true|on|yes|1)$/.test(value)) {
+    if(lodash.isNumber(value) || (""+value).match(/^[0-9]+$/)) {
+      return (value > 0);
+    } else if (value === true || /^(true|on|yes|1)$/.test(value)) {
       return true;
-    }  else if (value === 0 || value === false || /^(false|off|no|0)$/.test(value)) {
+    }  else if (value === false || /^(false|off|no|0)$/.test(value)) {
       return false;
     } else {
       return value;

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -41,9 +41,9 @@ module.exports = {
     }
   },
   toBoolean: function (value) {
-    if (value === 1 || value === true || /true|on|yes|1/.test(value)) {
+    if (value === 1 || value === true || /^(true|on|yes|1)$/.test(value)) {
       return true;
-    }  else if (value === 0 || value === false || /false|off|no|0/.test(value)) {
+    }  else if (value === 0 || value === false || /^(false|off|no|0)$/.test(value)) {
       return false;
     } else {
       return value;

--- a/test/transforms/index.js
+++ b/test/transforms/index.js
@@ -3,6 +3,7 @@ require("./compact");
 require("./custom");
 require("./deburr");
 require("./to_array");
+require("./to_boolean");
 require("./to_date");
 require("./to_float");
 require("./to_integer");

--- a/test/transforms/to_boolean.js
+++ b/test/transforms/to_boolean.js
@@ -140,5 +140,24 @@ describe("transforms", function () {
       expect(output.data).to.be.a("boolean");
       expect(output.data).to.eql(false);
     });
+
+    /**
+     * Boolean tests
+     */
+    it("should turn true into a true", function () {
+      var output = testSchema(true);
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(true);
+    });
+
+    it("should turn false into a false", function () {
+      var output = testSchema(false);
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(false);
+    });
   });
 });

--- a/test/transforms/to_boolean.js
+++ b/test/transforms/to_boolean.js
@@ -18,7 +18,7 @@ describe("transforms", function () {
       expect(output.data).to.eql(true);
     });
 
-    it("should turn 'bon/one' into a false", function () {
+    it("should not validate 'bon/one'", function () {
       var output1 = testSchema("bon");
       expect(output1.isValid).to.be(false);
 
@@ -34,7 +34,7 @@ describe("transforms", function () {
       expect(output.data).to.eql(true);
     });
 
-    it("should turn 'nyes/yess' into a false", function () {
+    it("should not validate 'nyes/yess'", function () {
       var output1 = testSchema("nyes");
       expect(output1.isValid).to.be(false);
 
@@ -50,7 +50,7 @@ describe("transforms", function () {
       expect(output.data).to.eql(true);
     });
 
-    it("should turn 'ttrue/truee' into a false", function () {
+    it("should not validate 'ttrue/truee'", function () {
       var output1 = testSchema("ttrue");
       expect(output1.isValid).to.be(false);
 
@@ -66,7 +66,7 @@ describe("transforms", function () {
       expect(output.data).to.eql(false);
     });
 
-    it("should turn 'ooff/offf' into a false", function () {
+    it("should not validate 'ooff/offf'", function () {
       var output1 = testSchema("ooff");
       expect(output1.isValid).to.be(false);
 
@@ -82,7 +82,7 @@ describe("transforms", function () {
       expect(output.data).to.eql(false);
     });
 
-    it("should turn 'nno/noo' into a false", function () {
+    it("should not validate 'nno/noo'", function () {
       var output1 = testSchema("nno");
       expect(output1.isValid).to.be(false);
 
@@ -98,7 +98,7 @@ describe("transforms", function () {
       expect(output.data).to.eql(false);
     });
 
-    it("should turn 'ffalse/falsee' into a false", function () {
+    it("should not validate 'ffalse/falsee'", function () {
       var output1 = testSchema("ffalse");
       expect(output1.isValid).to.be(false);
 

--- a/test/transforms/to_boolean.js
+++ b/test/transforms/to_boolean.js
@@ -1,0 +1,61 @@
+var expect = require("expect.js");
+var Hannibal = require("../../index");
+
+describe("transforms", function () {
+  var hannibal = new Hannibal();
+
+  describe.only("toBoolean", function () {
+    var testSchema = hannibal.create({
+      type: "boolean",
+      transforms: "toBoolean"
+    });
+
+    it("should turn 'on' into a true", function () {
+      var output = testSchema("on");
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(true);
+    });
+
+    it("should turn 'yes' into a true", function () {
+      var output = testSchema("yes");
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(true);
+    });
+
+    it("should turn 'true' into a true", function () {
+      var output = testSchema("true");
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(true);
+    });
+
+    it("should turn 'off' into a true", function () {
+      var output = testSchema("off");
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(false);
+    });
+
+    it("should turn 'no' into a true", function () {
+      var output = testSchema("no");
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(false);
+    });
+
+    it("should turn 'false' into a true", function () {
+      var output = testSchema("false");
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(false);
+    });
+  });
+});

--- a/test/transforms/to_boolean.js
+++ b/test/transforms/to_boolean.js
@@ -125,6 +125,22 @@ describe("transforms", function () {
       expect(output.data).to.eql(true);
     });
 
+    it("should turn 99 into a true", function () {
+      var output = testSchema(99);
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(true);
+    });
+
+    it("should turn '99' into a true", function () {
+      var output = testSchema('99');
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(true);
+    });
+
     it("should turn 0 into a false", function () {
       var output = testSchema(0);
 
@@ -135,6 +151,22 @@ describe("transforms", function () {
 
     it("should turn '0' into a false", function () {
       var output = testSchema(0);
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(false);
+    });
+
+    it("should turn -99 into a false", function () {
+      var output = testSchema(-99);
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(false);
+    });
+
+    it("should turn '-99' into a false", function () {
+      var output = testSchema(-99);
 
       expect(output.isValid).to.be(true);
       expect(output.data).to.be.a("boolean");

--- a/test/transforms/to_boolean.js
+++ b/test/transforms/to_boolean.js
@@ -105,5 +105,40 @@ describe("transforms", function () {
       var output2 = testSchema("falsee");
       expect(output2.isValid).to.be(false);
     });
+
+    /**
+     * Number tests
+     */
+    it("should turn 1 into a true", function () {
+      var output = testSchema(1);
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(true);
+    });
+
+    it("should turn '1' into a true", function () {
+      var output = testSchema('1');
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(true);
+    });
+
+    it("should turn 0 into a false", function () {
+      var output = testSchema(0);
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(false);
+    });
+
+    it("should turn '0' into a false", function () {
+      var output = testSchema(0);
+
+      expect(output.isValid).to.be(true);
+      expect(output.data).to.be.a("boolean");
+      expect(output.data).to.eql(false);
+    });
   });
 });

--- a/test/transforms/to_boolean.js
+++ b/test/transforms/to_boolean.js
@@ -18,12 +18,28 @@ describe("transforms", function () {
       expect(output.data).to.eql(true);
     });
 
+    it("should turn 'bon/one' into a false", function () {
+      var output1 = testSchema("bon");
+      expect(output1.isValid).to.be(false);
+
+      var output2 = testSchema("one");
+      expect(output2.isValid).to.be(false);
+    });
+
     it("should turn 'yes' into a true", function () {
       var output = testSchema("yes");
 
       expect(output.isValid).to.be(true);
       expect(output.data).to.be.a("boolean");
       expect(output.data).to.eql(true);
+    });
+
+    it("should turn 'nyes/yess' into a false", function () {
+      var output1 = testSchema("nyes");
+      expect(output1.isValid).to.be(false);
+
+      var output2 = testSchema("yess");
+      expect(output2.isValid).to.be(false);
     });
 
     it("should turn 'true' into a true", function () {
@@ -34,12 +50,28 @@ describe("transforms", function () {
       expect(output.data).to.eql(true);
     });
 
+    it("should turn 'ttrue/truee' into a false", function () {
+      var output1 = testSchema("ttrue");
+      expect(output1.isValid).to.be(false);
+
+      var output2 = testSchema("truee");
+      expect(output2.isValid).to.be(false);
+    });
+
     it("should turn 'off' into a true", function () {
       var output = testSchema("off");
 
       expect(output.isValid).to.be(true);
       expect(output.data).to.be.a("boolean");
       expect(output.data).to.eql(false);
+    });
+
+    it("should turn 'ooff/offf' into a false", function () {
+      var output1 = testSchema("ooff");
+      expect(output1.isValid).to.be(false);
+
+      var output2 = testSchema("offf");
+      expect(output2.isValid).to.be(false);
     });
 
     it("should turn 'no' into a true", function () {
@@ -50,12 +82,28 @@ describe("transforms", function () {
       expect(output.data).to.eql(false);
     });
 
+    it("should turn 'nno/noo' into a false", function () {
+      var output1 = testSchema("nno");
+      expect(output1.isValid).to.be(false);
+
+      var output2 = testSchema("noo");
+      expect(output2.isValid).to.be(false);
+    });
+
     it("should turn 'false' into a true", function () {
       var output = testSchema("false");
 
       expect(output.isValid).to.be(true);
       expect(output.data).to.be.a("boolean");
       expect(output.data).to.eql(false);
+    });
+
+    it("should turn 'ffalse/falsee' into a false", function () {
+      var output1 = testSchema("ffalse");
+      expect(output1.isValid).to.be(false);
+
+      var output2 = testSchema("falsee");
+      expect(output2.isValid).to.be(false);
     });
   });
 });

--- a/test/transforms/to_boolean.js
+++ b/test/transforms/to_boolean.js
@@ -4,7 +4,7 @@ var Hannibal = require("../../index");
 describe("transforms", function () {
   var hannibal = new Hannibal();
 
-  describe.only("toBoolean", function () {
+  describe("toBoolean", function () {
     var testSchema = hannibal.create({
       type: "boolean",
       transforms: "toBoolean"


### PR DESCRIPTION
Added tests for `toBoolean` also fixed logic
- `one` no longer passes as `true`
- `99` no passes as `true` / `-99` as `false`
