### PR TITLE
Fixed package definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Hannibal
 
-![circleci](https://circleci.com/gh/oliverbrooks/hannibal.png?style=shield)
-![Dependency Status](https://david-dm.org/oliverbrooks/hannibal.svg)
-![Dev Dependency Status](https://david-dm.org/oliverbrooks/hannibal/dev-status.svg)
+![circleci](https://circleci.com/gh/pearlshare/hannibal.png?style=shield)
+![Dependency Status](https://david-dm.org/pearlshare/hannibal.svg)
+![Dev Dependency Status](https://david-dm.org/pearlshare/hannibal/dev-status.svg)
 
 ![love it when a plan comes together](https://images.rapgenius.com/530583e79e4fc7f75855995d511e185c.400x294x1.jpg)
 

--- a/examples/tonic.js
+++ b/examples/tonic.js
@@ -1,0 +1,38 @@
+var Hannibal = require("hannibal");
+var hannibal = new Hannibal();
+
+// Create a validator by adding a schema
+var validator = hannibal.create({
+  type: "object",
+  schema: {
+    name: {
+      type: "string"
+    },
+    age: {
+      type: "number"
+    },
+    address: {
+      type: "object",
+      schema: {
+        street: {
+          type: "string"
+        },
+        city: {
+          type: "string"
+        }
+      }
+    }
+  }
+});
+
+// Check a valid user
+var rslt = validator({
+  name: "John Smith",
+  age: 53,
+  address: {
+    street: "The underground",
+    city: "Los Angeles"
+  }
+});
+
+console.log(rslt);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Validate JSON",
   "repository": {
     "type": "git",
-    "git": "https://github.com/oliverbrooks/hannibal.git"
+    "git": "https://github.com/pearlshare/hannibal.git"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.9",
   "description": "Validate JSON",
   "repository": {
+    "type": "git",
     "git": "https://github.com/oliverbrooks/hannibal.git"
   },
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "errors"
   ],
   "author": "",
+  "tonicExampleFilename": "examples/tonic.js",
   "license": "MIT",
   "devDependencies": {
     "eslint": "^0.24.0",


### PR DESCRIPTION
Fixed `package.json` and badges in `README.md` also added [tonicExampleFilename ](https://tonicdev.uservoice.com/knowledgebase/articles/765846-how-do-i-customize-the-example-for-my-npm-package) which should appear on the npm package page (https://www.npmjs.com/package/hannibal) under "Try it out"

Note you'll need to add the project again to circleci as the repo path has changed from `oliverbrooks` -> `pearlshare`
