### PR TITLE
Fixed package.json repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Validate JSON",
   "repository": {
     "type": "git",
-    "git": "https://github.com/pearlshare/hannibal.git"
+    "url": "https://github.com/pearlshare/hannibal.git"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The repository info isn't showing up https://www.npmjs.com/package/hannibal, I'm assuming this is the issue (as outlined https://docs.npmjs.com/files/package.json#repository)
